### PR TITLE
feat: bind /tmp/ as a tmpfs for bv_decide to create temp files

### DIFF
--- a/server/bubblewrap.sh
+++ b/server/bubblewrap.sh
@@ -12,7 +12,7 @@ if command -v bwrap >/dev/null 2>&1; then
     --ro-bind "$LEAN_ROOT" /lean \
     --ro-bind /usr /usr \
     --dev /dev \
-    --bind /tmp/ /tmp/ \
+    --tmpfs /tmp \
     --proc /proc \
     --symlink usr/lib /lib\
     --symlink usr/lib64 /lib64\

--- a/server/bubblewrap.sh
+++ b/server/bubblewrap.sh
@@ -12,6 +12,7 @@ if command -v bwrap >/dev/null 2>&1; then
     --ro-bind "$LEAN_ROOT" /lean \
     --ro-bind /usr /usr \
     --dev /dev \
+    --bind /tmp/ /tmp/ \
     --proc /proc \
     --symlink usr/lib /lib\
     --symlink usr/lib64 /lib64\


### PR DESCRIPTION
Since `bv_decide` uses temporary files to communicate with `cadical`, we bind `/tmp` as a read-write mount. This allows `bv_decide` to be successfully used in a hosted instance of `lean4web`: [Link here](https://lean-mlir.grosser.es/#codez=JYWwDg9gTgLgBAZQQQQFCkrRKB0AFKCAKwFMBjGAZxwEkA7SmAYQhACNg6ScAxaAWQCGMABYAbYG3Tho8JMnyFSFavUYt2nbnygIYAE2mY5uAsXJVaDZqw5ccAFUEVgZZAFcYEVKkokYAPoQYDDAEHRwEnQwJFA47nTufvpOLmRwAGaCYn6+/kEhYRFRMXEJUCTOIoJsYiSpoelZOSQ+dIIgJJRgziRwAEKClK4+AG6CUMA1dXAA3gAecACecABecABcA8AwAGrkcADuAL4+APQAtHAATBcAjHAAIn380ADmgnSAmASUcAAygkOvwAovMYnR9CR9HALmcfKISNASCA4HQIIFPvoAiQAI4BNGBaD49GbVBwclwAB+1LgAApFgAyJnLACUcAAvFSaYsAD58rmU5abTlsJZkuAwKArbLAUYkAKCTzecnZMQBN4QbK/SjQKXwkSIiooglBKDYvEmzHE+AbcXk6mC+lwPk81kcgVwRnMh1CjYisXkyXSiRyhVK8Wq9WanJwHVQPWoBFI43ohX6LHheW460BSjuNhBLikikep0AajgdzZnJ9iyuDz9cFF4qDcBlocVXgjYjVGq1sd1YsTBuTqNTeYLmfNOcE6cLfVtJZ9Tvr1Y9iwrDf9LalbZD8s7yr3vej2sHPgAxGQDWQANZjwIT+fTy1zzM+EgQgZDEZAA).

The line of code that perform this is:

```lean
-- https://github.com/leanprover/lean4/blob/master/src/Lean/Elab/Tactic/BVDecide/Frontend/BVDecide.lean#L167-L168
Frontend/BVDecide.lean
167:    IO.FS.withTempFile fun _ lratFile => do
168:      let cfg ← BVDecide.Frontend.TacticContext.new lratFile
```

CC @hargonix 