### PR TITLE
Support reading showGoalNames from URL params on page load

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,9 +9,10 @@ import { faCode } from '@fortawesome/free-solid-svg-icons'
 
 // Local imports
 import LeanLogo from './assets/logo.svg'
-import defaultSettings, { Entries, IPreferencesContext, lightThemes, preferenceParams } from './config/settings'
+import defaultSettings, { IPreferencesContext, lightThemes, preferenceParams } from './config/settings'
 import { Menu } from './Navigation'
 import { PreferencesContext } from './Popups/Settings'
+import { Entries } from './utils/Entries'
 import { fixedEncodeURIComponent, formatArgs, lookupUrl, parseArgs } from './utils/UrlParsing'
 import { useWindowDimensions } from './utils/WindowWidth'
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -131,7 +131,8 @@ function App() {
     if (!loaded) { return }
 
     const _mobile = width < 800
-    if (!preferences.saveInLocalStore && _mobile !== preferences.mobile) {
+    const searchParams = new URLSearchParams(window.location.search);
+    if (!(searchParams.has("mobile") || preferences.saveInLocalStore) && _mobile !== preferences.mobile) {
       setPreferences({ ...preferences, mobile: _mobile })
     }
   }, [width, loaded])

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -88,22 +88,20 @@ function App() {
     console.debug('[Lean4web] Loading preferences')
 
     let saveInLocalStore = false;
-    let newPreferences: Record<keyof IPreferencesContext, any> = { ...preferences }
+    let newPreferences: { [K in keyof IPreferencesContext]: IPreferencesContext[K] } = { ...preferences }
     for (const [key, value] of (Object.entries(preferences) as Entries<IPreferencesContext>)) {
-      let storedValue = window.localStorage.getItem(key)
       // prefer URL params over stored
       const searchParams = new URLSearchParams(window.location.search);
-      if (preferenceParams.includes(key) && searchParams.has(key)) {
-        const paramValue = !(searchParams.get(key) === "false")  // expecting true or false
-        console.debug(`[Lean4web] Found URL value for ${key}: ${paramValue}`)
-        newPreferences[key] = paramValue
-      } else if (storedValue) {
-        saveInLocalStore = true
-        console.debug(`[Lean4web] Found stored value for ${key}: ${storedValue}`)
+      let storedValue = (
+        preferenceParams.includes(key) &&  // only for keys we explictly check for
+        searchParams.has(key) && searchParams.get(key))
+        ?? window.localStorage.getItem(key)
+      if (storedValue) {
+        saveInLocalStore = window.localStorage.getItem(key) === storedValue
+        console.debug(`[Lean4web] Found value for ${key}: ${storedValue}`)
         if (typeof value === 'string') {
           newPreferences[key] = storedValue
         } else if (typeof value === 'boolean') {
-          // Boolean values
           newPreferences[key] = (storedValue === "true")
         } else {
           // other values aren't implemented yet.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -100,7 +100,13 @@ function App() {
         saveInLocalStore = window.localStorage.getItem(key) === storedValue
         console.debug(`[Lean4web] Found value for ${key}: ${storedValue}`)
         if (typeof value === 'string') {
-          newPreferences[key] = storedValue
+          if (key == 'theme') {
+            const theme = storedValue.toLowerCase().includes('dark') ? "Visual Studio Dark" : "Visual Studio Light"
+            newPreferences[key] = theme
+          }
+          else {
+            newPreferences[key] = storedValue
+          }
         } else if (typeof value === 'boolean') {
           newPreferences[key] = (storedValue === "true")
         } else {

--- a/client/src/config/settings.ts
+++ b/client/src/config/settings.ts
@@ -18,10 +18,6 @@ export interface IPreferencesContext {
   wordWrap: boolean
 }
 
-export type Entries<T> = {
-    [K in keyof T]-?: [K, T[K]];
-}[keyof T][];
-
 export const preferenceParams: (keyof IPreferencesContext)[] = ["showGoalNames"]
 
 /** The default settings. */

--- a/client/src/config/settings.ts
+++ b/client/src/config/settings.ts
@@ -18,6 +18,12 @@ export interface IPreferencesContext {
   wordWrap: boolean
 }
 
+export type Entries<T> = {
+    [K in keyof T]-?: [K, T[K]];
+}[keyof T][];
+
+export const preferenceParams: (keyof IPreferencesContext)[] = ["showGoalNames"]
+
 /** The default settings. */
 const settings: IPreferencesContext = {
   abbreviationCharacter: '\\',

--- a/client/src/config/settings.ts
+++ b/client/src/config/settings.ts
@@ -6,6 +6,8 @@ Note that more Editor options are set in `App.tsx` directly.
 
 // const isBrowserDefaultDark = () => window.matchMedia('(prefers-color-scheme: dark)').matches
 
+type Theme = "Visual Studio Light" | "Visual Studio Dark"
+
 /** Type for the user settings. */
 export interface IPreferencesContext {
   /** Lead character to trigger unicode input mode */
@@ -21,7 +23,7 @@ export interface IPreferencesContext {
   mobile: boolean
   saveInLocalStore: boolean
   /** Light or dark. Usually inferred from browser dark mode preferences. */
-  theme: string
+  theme: Theme
   /** Wrap code */
   wordWrap: boolean
 }
@@ -55,7 +57,7 @@ const settings: IPreferencesContext = {
  * If you add a Monaco theme, the mobile code-mirror editor will default to its dark theme,
  * unless the theme is in this list.
  */
-export const lightThemes = [
+export const lightThemes: Theme[] = [
   'Visual Studio Light'
 ]
 

--- a/client/src/config/settings.ts
+++ b/client/src/config/settings.ts
@@ -8,13 +8,21 @@ Note that more Editor options are set in `App.tsx` directly.
 
 /** Type for the user settings. */
 export interface IPreferencesContext {
+  /** Lead character to trigger unicode input mode */
   abbreviationCharacter: string
+  /** Accept code editors suggestions on Enter */
   acceptSuggestionOnEnter: boolean
+  /** Show goal names in Lean infoview box */
   showGoalNames: boolean
-  compress: boolean, // compress the `code=` in the URL into `codez=` using LZ-string
+  /** Compress the `code=` in the URL into `codez=` using LZ-string */
+  compress: boolean, 
+  /** Display code editor and infoview in narrow, vertically stacked, mobile-friendly mode.
+   * Usually inferred from window width. */
   mobile: boolean
   saveInLocalStore: boolean
-  theme: string,
+  /** Light or dark. Usually inferred from browser dark mode preferences. */
+  theme: string
+  /** Wrap code */
   wordWrap: boolean
 }
 
@@ -34,7 +42,9 @@ const settings: IPreferencesContext = {
   acceptSuggestionOnEnter: false,
   showGoalNames: true,
   compress: true,
-  mobile: false, // value irrelevant as it will be overwritten with `width < 800` in App.tsx
+  /** value likely overwritten with `width < 800` in App.tsx
+   * unless provided in URL searchparams or in local storage. */
+  mobile: false,
   saveInLocalStore: false, // should be false unless user gave consent.
   theme: 'Visual Studio Light', // irrelevant as it will be overwritten in App.tsx
   wordWrap: true

--- a/client/src/config/settings.ts
+++ b/client/src/config/settings.ts
@@ -18,7 +18,15 @@ export interface IPreferencesContext {
   wordWrap: boolean
 }
 
-export const preferenceParams: (keyof IPreferencesContext)[] = ["showGoalNames"]
+export const preferenceParams: (keyof IPreferencesContext)[] = [
+  "abbreviationCharacter",
+  "acceptSuggestionOnEnter",
+  // "compress", // not sure if this should be user-settable
+  "showGoalNames",
+  "mobile",
+  "theme",
+  "wordWrap",
+]
 
 /** The default settings. */
 const settings: IPreferencesContext = {

--- a/client/src/utils/Entries.ts
+++ b/client/src/utils/Entries.ts
@@ -1,0 +1,12 @@
+/** Typing hinter for Object.entries of an interface.
+We have some interface `T`, and thus the type of keys/attributes of as `keyof T`.
+`[K in keyof T]` is a key of `T` lifted to a type.
+`-?` means that the key in the `{...}` object type we are building is required.
+`[K, T[K]]` is the type of pairs of the key and its value.
+So `{[K in keyof T]-?: [K, T[K]]}` is the type of objects with keys of T
+(protomed to types) and values as the tuples of entries of T.
+We index into this object with `[keyof T]` to get the pairs of key,value,
+and finally with a `[]` to get the array of pairs. */
+export type Entries<T> = {
+    [K in keyof T]-?: [K, T[K]];
+}[keyof T][];

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -24,3 +24,17 @@ logic:
 1. if the code matches the one from the loaded URL, use `url`
 2. if the preferences say no comression, use `code`
 3. otherwise use `codez` or `code` depending on which results in a shorter URL.
+
+### URL parameters
+
+Besides storing the settings in a cookie through the settings interface, there is an option to specify them in the form `https://myserver.com/?setting1=value1&setting2=value2#[arguments as above]`
+When a setting is not provided as URL parameters, the default value for it is used.
+
+The recognized settings are:
+
+- `abbreviationCharacter`: Leader character to type to introduce abbrevations, default is `\`
+- `acceptSuggestionOnEnter`: Accept code editors suggestions on Enter, default is false
+- `showGoalNames`: Show goal names in Lean infoview box, default is true
+- `mobile`: Display code editor and infoview in narrow, vertically stacked, mobile-friendly mode. Usually inferred from window width.
+- `theme`: `light` or `dark`. Usually inferred from browser dark mode preferences.
+- `wordWrap`: Wrap code in editor box, default is true

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -36,5 +36,5 @@ The recognized settings are:
 - `acceptSuggestionOnEnter`: Accept code editors suggestions on Enter, default is false
 - `showGoalNames`: Show goal names in Lean infoview box, default is true
 - `mobile`: Display code editor and infoview in narrow, vertically stacked, mobile-friendly mode. Usually inferred from window width.
-- `theme`: `light` or `dark`. Usually inferred from browser dark mode preferences.
+- `theme`: Light or dark. Usually inferred from browser dark mode preferences.
 - `wordWrap`: Wrap code in editor box, default is true


### PR DESCRIPTION
Only on initial load; overrides the stored preferences

With expansion possibility for other preference keys In the future, might want to also _set_ params
with useSearchParams hook
although I ran into
https://github.com/remix-run/react-router/issues/12785 trying that

Also clean up TODO about typing of newPreferences

Fixes: #52

-------

[Without searchparams](http://localhost:3000/#codez=KYDwhgtgDgNsAEAKAdvAXPAcmALgSnXgDEwYBnBNAXngCMBPAKHngGMwKz5kg):
![image](https://github.com/user-attachments/assets/f60c1543-39cc-4d7f-a9d9-755522e9548a)

[With searchparams](http://localhost:3000/?showGoalNames=false#codez=KYDwhgtgDgNsAEAKAdvAXPAcmALgSnXgDEwYBnBNAXngCMBPAKHngGMwKz5kg):
![image](https://github.com/user-attachments/assets/69ab0abb-2481-44a2-b422-cec95f37019e)
