### PR TITLE
fix: move uri encoding to formatArgs

### DIFF
--- a/client/src/editor/code-atoms.ts
+++ b/client/src/editor/code-atoms.ts
@@ -4,7 +4,6 @@ import LZString from 'lz-string'
 import { settingsAtom } from '../settings/settings-atoms'
 import { importedCodeAtom, importUrlAtom, importUrlBaseAtom } from '../store/import-atoms'
 import { urlArgsAtom, urlArgsStableAtom } from '../store/url-atoms'
-import { fixedEncodeURIComponent } from '../utils/UrlParsing'
 
 /** Atom which represents the editor content and synchronises it with the url hash. */
 export const codeAtom = atom(
@@ -37,7 +36,7 @@ export const codeAtom = atom(
     if (code == importedCode) {
       set(urlArgsAtom, {
         ...urlArgs,
-        url: fixedEncodeURIComponent(url),
+        url: url,
         code: undefined,
         codez: undefined,
       })
@@ -49,11 +48,10 @@ export const codeAtom = atom(
         ...urlArgs,
         url: undefined,
         code: undefined,
-        codez: fixedEncodeURIComponent(compressedCode),
+        codez: compressedCode,
       })
     } else {
-      const encodedCode = fixedEncodeURIComponent(code)
-      set(urlArgsAtom, { ...urlArgs, url: undefined, code: encodedCode, codez: undefined })
+      set(urlArgsAtom, { ...urlArgs, url: undefined, code: code, codez: undefined })
     }
   },
 )

--- a/client/src/store/import-atoms.ts
+++ b/client/src/store/import-atoms.ts
@@ -1,7 +1,7 @@
 import { atom } from 'jotai'
 import { atomWithQuery } from 'jotai-tanstack-query'
 
-import { fixedEncodeURIComponent, lookupUrl } from '../utils/UrlParsing'
+import { lookupUrl } from '../utils/UrlParsing'
 import { currentProjectAtom } from './project-atoms'
 import { urlArgsAtom, urlArgsStableAtom } from './url-atoms'
 
@@ -26,7 +26,7 @@ export const importUrlAtom = atom(
     set(importUrlBaseAtom, url)
     set(urlArgsAtom, {
       ...urlArgs,
-      url: fixedEncodeURIComponent(url),
+      url: url,
       code: undefined,
       codez: undefined,
     })

--- a/client/src/store/url-converters.ts
+++ b/client/src/store/url-converters.ts
@@ -1,3 +1,4 @@
+import { fixedEncodeURIComponent } from '../utils/UrlParsing'
 import { UrlArgs } from './url-types'
 
 /**
@@ -9,7 +10,7 @@ export function formatArgs(args: UrlArgs): string {
     '#' +
     Object.entries(args)
       .filter(([_key, val]) => (val?.trim().length ?? 0) > 0)
-      .map(([key, val]) => `${key}=${val}`)
+      .map(([key, val]) => `${key}=${fixedEncodeURIComponent(val)}`)
       .join('&')
   if (out == '#') {
     return ''


### PR DESCRIPTION
Resolves #109.

Moves the responsibility for calling `fixedEncodeURIComponent` to `formatArgs`. I tried to ensure that there's no double-encoding happening as a result of this change. I don't see any other callers of `fixedEncodeURIComponent` or `encodeURIComponent` after this change.

I locally tested that the behavior in #109 is eliminated. I tried copying and pasting well-formed `code=` and `codez=` URIs, editing, changing projects, Import-from-file functionality.