### PR TITLE
Prevent history entries on every keystroke

### DIFF
--- a/client/src/store/location-atoms.ts
+++ b/client/src/store/location-atoms.ts
@@ -1,3 +1,3 @@
 import { atomWithLocation } from 'jotai-location'
 
-export const locationAtom = atomWithLocation()
+export const locationAtom = atomWithLocation({ replace: true })


### PR DESCRIPTION
`jotai-location` defaults to `pushState`. As a result a new entry is added to the browser history on every change that impacts the URL, including keystrokes in the editor. [`replace: true`](https://jotai.org/docs/extensions/location#options) uses `replaceState` instead and will update the current history entry.