### PR TITLE
fix: height of the infoview

### DIFF
--- a/client/src/css/Editor.css
+++ b/client/src/css/Editor.css
@@ -1,12 +1,7 @@
-.editor-wrapper {
-  flex: 1;
-  min-height: 0;
-  padding-top: 0.5rem;
-}
-
 .editor {
   display: flex;
   flex: 1;
+  min-height: 0;
 }
 
 .codeview-wrapper {


### PR DESCRIPTION
There's a (generally minor) problem where if you resize the window smaller, the "Restart File" button gets hidden. Flexbox sets `min-height` to [`auto`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/min-height#auto), which apparently means it can't shrink beyond its initial height. min-height 0 fixes this.

(And the editor-wrapper class isn't mentioned anywhere so this deletes it.)