### PR TITLE
fix: enable compression for large websocket messages

### DIFF
--- a/server/index.mjs
+++ b/server/index.mjs
@@ -181,7 +181,19 @@ if (crtFile && keyFile) {
   server = app.listen(PORT, () => console.log(`HTTP on port ${PORT}`))
 }
 
-const wss = new WebSocketServer({ server })
+const wss = new WebSocketServer({
+  server,
+  perMessageDeflate: {
+    // Only compress large messages (e.g. the full-environment completion
+    // dumps). `threshold` is only honored when context takeover is disabled
+    // on the sending side, so `serverNoContextTakeover` is required here for
+    // the threshold to take effect on server->client messages.
+    // Default threshold is 1024 bytes.
+    // (cf. https://github.com/microsoft/playwright/issues/33810)
+    threshold: 16 * 1024 * 1024, // 16 MB
+    serverNoContextTakeover: true,
+  },
+})
 
 function startServerProcess(project) {
   const PROJECT_PATH = path.join(PROJECTS_BASE_PATH, project)


### PR DESCRIPTION
This change enables per-message "deflate" compression in the websocket server used to communicate with lean4web clients, for messages larger than 16MB, attempting to avoid the cost of compressing the many small messages that don't benefit from it.

This is hoped to improve responsiveness for users of `http://live.lean-lang.org/`. The current most convenient repro is typing
```
import Mathlib

example : a ≠ d * d + a := by omega
```
into the buffer and rapidly deleting and retyping the `+ a`. The symptom is that sometimes the infoview yellow spinner stays active for quite a while, 5s-30s depending on hardware and network circumstances.

Full completions when mathlib is imported can be on the order of 200k items, on the order of 20-40MB jsonrpc responses. Because these are on the same websocket connection as `$/lean/fileProgress`, we may block on transferring the completions response before communicating to the user that elaboration has finished successfully. This sometimes leads to reportedly 10-30s user-visible latency between finishing typing and waiting for the yellow spinner in the infoview to resolve.

In practice, completions appear to be compressed by a factor of 8-9x by the deflate algorithm supported by websockets. We expect this should improve user-facing (non-completion) responsiveness when large completions are in flight, as other factors such as JSON.parse or toString are measured as negligible (well under 100ms) for the same payload. It may also improve end-to-end completion responsiveness itself, but probably at most only by a factor of about 2x according to experiments.