### PR TITLE
feat: allow build.sh script to be skipped

### DIFF
--- a/server/build.sh
+++ b/server/build.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ -n "$LEAN4WEB_SKIP_PROJECT_BUILD" ]; then
+  echo "Skipping build because LEAN4WEB_SKIP_PROJECT_BUILD is set"
+  exit 0
+fi
+
 PROJECTS_BASE_PATH=${PROJECTS_BASE_PATH:-"Projects"}
 
 cd "$(dirname $0)/../$PROJECTS_BASE_PATH"


### PR DESCRIPTION
At the FRO we run a separate periodic script to update our project dependencies rather than requiring a redeploy and do not build projects at deploy time — this would support that workflow better than overwriting the build.sh script, which is what we do now.