### PR TITLE
Moving description of `ruler` to Non-boolean settings in `Usage.md`

### DIFF
--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -42,10 +42,10 @@ The recognised settings are:
   - `showGoalNames`: show goal names in Lean infoview box. default: `true`
   - `showExpectedType`: expected type in Lean infoview opened by default. default: `false`
   - `wordWrap`: wrap code in editor box. default: `true`
-  - `ruler`: a `number`. If specified, the column at which to display the ruler. default: ``
 - Non-boolean settings:
-- `abbreviationCharacter`: lead character for unicode abbreviations. values: a character. default: `\`
-- `theme`: selection between one light and dark theme. More themes are available in the settings, but they cannot be set through the URL. values: `light` or `dark`. default: `light` (TODO: infererred from browser)
+  - `ruler`: a `number`. If specified, the column at which to display the ruler. default: ``
+  - `abbreviationCharacter`: lead character for unicode abbreviations. values: a character. default: `\`
+  - `theme`: selection between one light and dark theme. More themes are available in the settings, but they cannot be set through the URL. values: `light` or `dark`. default: `light` (TODO: infererred from browser)
 
 ### Collaboration
 


### PR DESCRIPTION
`ruler` was previously described as a setting with a `Boolean` value. It is a number not a boolean, and should be described under non-boolean settings.