### PR TITLE
feat: improved focus navigation

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -35,7 +35,6 @@ import { screenWidthAtom } from './store/window-atoms'
 import { getCollaboratorColor } from './utils/collabColors'
 import { save } from './utils/SaveToFile'
 import { useEscape } from './hooks/useEscape'
-import { QuickLinkMenu } from './navigation/QuickLinkMenu'
 
 const CodeMirrorEditor = lazy(() => import('./editor/CodeMirrorEditor'))
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -34,12 +34,17 @@ import { currentProjectAtom } from './store/project-atoms'
 import { screenWidthAtom } from './store/window-atoms'
 import { getCollaboratorColor } from './utils/collabColors'
 import { save } from './utils/SaveToFile'
+import { useEscape } from './hooks/useEscape'
+import { QuickLinkMenu } from './navigation/QuickLinkMenu'
 
 const CodeMirrorEditor = lazy(() => import('./editor/CodeMirrorEditor'))
 
-function App() {
+export function App() {
+  const editorWrapperRef = useRef<HTMLDivElement>(null)
   const editorRef = useRef<HTMLDivElement>(null)
   const infoviewRef = useRef<HTMLDivElement>(null)
+  const firstItemRef = useRef<HTMLButtonElement>(null)
+
   const [dragging, setDragging] = useState<boolean | null>(false)
   const [editor, setEditor] = useState<monaco.editor.IStandaloneCodeEditor>()
   const [leanMonaco, setLeanMonaco] = useState<LeanMonaco>()
@@ -155,6 +160,10 @@ function App() {
     ydoc.destroy()
     usernamesRef.current.clear()
   }
+
+  useEscape(editorWrapperRef, () => {
+    firstItemRef.current?.focus()
+  })
 
   // this effect manages the lifetime of the editor binding
   useEffect(() => {
@@ -318,6 +327,7 @@ function App() {
               let newTab = window.open(
                 `https://leanprover-community.github.io/mathlib4_docs/${path}.html`,
                 '_blank',
+                'noopener',
               )
               if (newTab) {
                 newTab.focus()
@@ -542,6 +552,7 @@ function App() {
         style={{ flexDirection: mobile ? 'column' : 'row' }}
       >
         <div
+          ref={editorWrapperRef}
           className="codeview-wrapper"
           style={mobile ? { width: '100%' } : { height: '100%' }}
         >
@@ -579,5 +590,3 @@ function App() {
     </div>
   )
 }
-
-export default App

--- a/client/src/Popups/Tools.tsx
+++ b/client/src/Popups/Tools.tsx
@@ -139,6 +139,7 @@ function ToolTip({ pkg }: { pkg: LakePackage }) {
       className="tooltip"
       href={`${pkg.url}/commits/${pkg.rev}/`}
       target="_blank"
+      rel="noopener"
     >
       {pkg.rev.substring(0, 7)}
       <div className="tooltiptext" id="tooltip-content">

--- a/client/src/css/Navigation.css
+++ b/client/src/css/Navigation.css
@@ -28,7 +28,7 @@ nav select {
 
 /* A dropdown comprises a `nav-link` and a `dropdown-content`. The latter has absolute
 positioning to be displayed on top of things. */
-nav .dropdown {
+nav > .dropdown {
   display: inline-block;
   position: relative;
 }
@@ -53,7 +53,7 @@ nav .dropdown-content .dropdown .dropdown-content {
   left: 0;
 }
 /* Second level dropdowns */
-nav .dropdown-content .dropdown > .nav-link {
+nav .dropdown-content .dropdown .nav-link {
   /* Don't know why but apparently that yields the correct width. */
   display: block;
 }
@@ -81,6 +81,11 @@ nav select {
   padding-top: 0.6rem;
   padding-bottom: 0.6rem;
   flex-shrink: 0;
+  font-size: 1rem;
+}
+
+nav .dropdown-content .nav-link {
+  text-align: left;
 }
 
 /* Zulip logo (instead of font-awesome icon) */
@@ -189,4 +194,23 @@ nav .nav-link.leave-collab-button:hover {
 .tooltip .tooltiptext .commit-sha {
   font-style: italic;
   color: var(--vscode-textLink-foreground);
+}
+
+.quicklink {
+  position: absolute;
+  display: flex;
+  padding-left: 0.2rem;
+  padding-right: 0.2rem;
+  gap: 0.2rem;
+  align-items: center;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  background-color: var(--vscode-list-dropBackground);
+  transform: translateY(-200%);
+  transition: transform 150ms ease;
+}
+
+.quicklink:focus-within {
+  transform: translateY(0);
 }

--- a/client/src/hooks/useEscape.tsx
+++ b/client/src/hooks/useEscape.tsx
@@ -1,0 +1,22 @@
+import { RefObject, useEffect } from 'react'
+
+/** Hook which activates on `Esc` if the focus is within the component */
+export function useEscape(
+  ref: RefObject<HTMLElement | null>,
+  onEscape: () => void,
+) {
+  useEffect(() => {
+    const handler = (ev: KeyboardEvent) => {
+      if (
+        ev.key === 'Escape' &&
+        ref.current?.contains(document.activeElement)
+      ) {
+        ev.stopPropagation()
+        onEscape()
+      }
+    }
+
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [ref, onEscape])
+}

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -3,7 +3,7 @@ import './css/index.css'
 import { StrictMode } from 'react'
 import ReactDOM from 'react-dom/client'
 
-import App from './App.tsx'
+import { App } from './App.tsx'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/client/src/navigation/Dropdown.tsx
+++ b/client/src/navigation/Dropdown.tsx
@@ -1,7 +1,8 @@
 import { IconDefinition } from '@fortawesome/free-solid-svg-icons'
-import { MouseEventHandler, ReactNode } from 'react'
+import { MouseEventHandler, ReactNode, useRef } from 'react'
 
 import { NavButton } from './NavButton'
+import { useEscape } from '../hooks/useEscape'
 
 /** A button to appear in the hamburger menu or the navigation bar. */
 export function Dropdown({
@@ -18,12 +19,18 @@ export function Dropdown({
   icon?: IconDefinition
   text?: string
   useOverlay?: boolean
-  onClick?: MouseEventHandler<HTMLAnchorElement>
+  onClick?: MouseEventHandler<HTMLElement>
   children?: ReactNode
 }) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEscape(ref, () => {
+    setOpen(false)
+  })
+
   return (
     <>
-      <div className="dropdown">
+      <div ref={ref} className="dropdown">
         <NavButton
           icon={icon}
           text={text!}
@@ -33,17 +40,11 @@ export function Dropdown({
             ev.stopPropagation()
           }}
         />
-        {open && (
-          <div
-            className={`dropdown-content${open ? '' : ' '}`}
-            onClick={() => setOpen(false)}
-          >
-            {children}
-          </div>
-        )}
+        {open && <div className="dropdown-content">{children}</div>}
       </div>
       {useOverlay && open && (
         <div
+          aria-hidden={true}
           className="dropdown-overlay"
           onClick={(ev) => {
             setOpen(false)

--- a/client/src/navigation/NavButton.tsx
+++ b/client/src/navigation/NavButton.tsx
@@ -1,27 +1,43 @@
 import { IconDefinition } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { JSX } from 'react'
+import { JSX, RefObject } from 'react'
 
 /** A button to appear in the hamburger menu or to navigation bar. */
 export function NavButton({
   icon,
   iconElement,
   text,
+  href,
+  ref,
   ...props
 }: {
   icon?: IconDefinition
   iconElement?: JSX.Element
   text: string
-} & React.AnchorHTMLAttributes<HTMLAnchorElement>) {
-  // note: it seems that we can just leave the `target="_blank"` and it has no
-  // effect on links without a `href`. If not, add `if (href)` statement here...
+  href?: string
+  ref?: RefObject<HTMLButtonElement | null>
+} & React.AnchorHTMLAttributes<HTMLElement>) {
+  if (href)
+    return (
+      <a
+        {...props}
+        href={href}
+        className={props.className ? `nav-link ${props.className}` : 'nav-link'}
+        target="_blank"
+        rel="noopener"
+      >
+        {iconElement ?? <FontAwesomeIcon icon={icon!} />}&nbsp;
+        <span>{text}</span>
+      </a>
+    )
   return (
-    <a
+    <button
       {...props}
+      ref={ref}
+      type={undefined}
       className={props.className ? `nav-link ${props.className}` : 'nav-link'}
-      target="_blank"
     >
       {iconElement ?? <FontAwesomeIcon icon={icon!} />}&nbsp;<span>{text}</span>
-    </a>
+    </button>
   )
 }

--- a/client/src/navigation/Navigation.tsx
+++ b/client/src/navigation/Navigation.tsx
@@ -20,13 +20,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useAtom } from 'jotai'
-import {
-  ChangeEvent,
-  Dispatch,
-  RefObject,
-  SetStateAction,
-  useState,
-} from 'react'
+import { ChangeEvent, Dispatch, SetStateAction, useState } from 'react'
 
 import { lean4webConfig } from '../../config'
 import ZulipIcon from '../assets/zulip.svg'

--- a/client/src/navigation/Navigation.tsx
+++ b/client/src/navigation/Navigation.tsx
@@ -20,7 +20,13 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useAtom } from 'jotai'
-import { ChangeEvent, Dispatch, SetStateAction, useState } from 'react'
+import {
+  ChangeEvent,
+  Dispatch,
+  RefObject,
+  SetStateAction,
+  useState,
+} from 'react'
 
 import { lean4webConfig } from '../../config'
 import ZulipIcon from '../assets/zulip.svg'
@@ -112,6 +118,7 @@ function FlexibleMenu({
                   project: it.folder,
                 })
                 setOpenExample(false)
+                setOpenNav(false)
               }}
             />
           )),
@@ -149,6 +156,7 @@ function FlexibleMenu({
           text="Load from URL"
           onClick={() => {
             setLoadUrlOpen(true)
+            setOpenNav(false)
           }}
         />
         <NavButton
@@ -156,6 +164,7 @@ function FlexibleMenu({
           text="Load Zulip Message"
           onClick={() => {
             setLoadZulipOpen(true)
+            setOpenNav(false)
           }}
         />
       </Dropdown>
@@ -165,6 +174,7 @@ function FlexibleMenu({
           text="Collaborate"
           onClick={() => {
             setJoinCollabOpen(true)
+            setOpenNav(false)
           }}
         />
       )}
@@ -278,23 +288,31 @@ export function Menu({
           text="Settings"
           onClick={() => {
             setSettingsOpen(true)
+            setOpenNav(false)
           }}
         />
         <NavButton
           icon={faHammer}
           text="Lean Info"
-          onClick={() => setToolsOpen(true)}
+          onClick={() => {
+            setToolsOpen(true)
+            setOpenNav(false)
+          }}
         />
         <NavButton
           icon={faArrowRotateRight}
           text="Restart server"
-          onClick={restart}
+          onClick={() => {
+            restart?.()
+            setOpenNav(false)
+          }}
         />
         <NavButton
           icon={faDownload}
           text="Save"
           onClick={() => {
             if (code !== undefined) save(code, project?.folder)
+            setOpenNav(false)
           }}
         />
         <NavButton
@@ -302,6 +320,7 @@ export function Menu({
           text={'Privacy policy'}
           onClick={() => {
             setPrivacyOpen(true)
+            setOpenNav(false)
           }}
         />
         {hasImpressum && (
@@ -310,6 +329,7 @@ export function Menu({
             text={'Impressum'}
             onClick={() => {
               setImpressumOpen(true)
+              setOpenNav(false)
             }}
           />
         )}
@@ -317,16 +337,25 @@ export function Menu({
           icon={faArrowUpRightFromSquare}
           text="Lean community"
           href="https://leanprover-community.github.io/"
+          onClick={() => {
+            setOpenNav(false)
+          }}
         />
         <NavButton
           icon={faArrowUpRightFromSquare}
           text="Lean FRO"
           href="https://lean-lang.org"
+          onClick={() => {
+            setOpenNav(false)
+          }}
         />
         <NavButton
           icon={faArrowUpRightFromSquare}
           text="GitHub"
           href="https://github.com/leanprover-community/lean4web"
+          onClick={() => {
+            setOpenNav(false)
+          }}
         />
       </Dropdown>
       <PrivacyPopup

--- a/client/src/navigation/Popup.tsx
+++ b/client/src/navigation/Popup.tsx
@@ -1,5 +1,6 @@
-import { ReactNode, useEffect } from 'react'
+import { ReactNode, useRef } from 'react'
 import { FocusTrap } from 'focus-trap-react'
+import { useEscape } from '../hooks/useEscape'
 
 /** A popup which overlays the entire screen. */
 export function Popup({
@@ -11,19 +12,11 @@ export function Popup({
   handleClose: () => void // TODO: what's the correct type?
   children?: ReactNode
 }) {
-  useEffect(() => {
-    if (!open) return
-    const handleKeyDown = (ev: KeyboardEvent) => {
-      if (ev.key === 'Escape') {
-        ev.preventDefault()
-        handleClose()
-      }
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [open, handleClose])
+  const ref = useRef<HTMLDialogElement>(null)
+
+  useEscape(ref, () => {
+    handleClose()
+  })
 
   if (!open) return
   return (
@@ -34,7 +27,7 @@ export function Popup({
         onClick={handleClose}
       />
       <FocusTrap>
-        <dialog className="modal" open={open}>
+        <dialog ref={ref} className="modal" open={open}>
           <button
             className="codicon codicon-close modal-close"
             aria-label="close dialog"

--- a/client/src/navigation/QuickLinkMenu.tsx
+++ b/client/src/navigation/QuickLinkMenu.tsx
@@ -1,0 +1,34 @@
+import { RefObject } from 'react'
+import { NavButton } from './NavButton'
+
+/**
+ * The quicklink menu provides some "jump to" to jump
+ * focus to important places.
+ * This is to improve accessibility, see WCAG section 2.4
+ */
+export function QuickLinkMenu({
+  ref,
+  infoviewRef,
+  editorRef,
+}: {
+  ref?: RefObject<HTMLButtonElement | null>
+  infoviewRef: RefObject<HTMLButtonElement | null>
+  editorRef: RefObject<HTMLButtonElement | null>
+}) {
+  return (
+    <div className="quicklink">
+      <span>Jump to:</span>
+      <NavButton
+        ref={ref}
+        text="Infoview"
+        aria-label="jump to Infoview"
+        // TODO: focus infoview
+      />
+      <NavButton
+        text="Editor"
+        aria-label="jump to Editor"
+        // TODO: focus editor
+      />
+    </div>
+  )
+}

--- a/client/src/navigation/QuickLinkMenu.tsx
+++ b/client/src/navigation/QuickLinkMenu.tsx
@@ -8,7 +8,9 @@ import { NavButton } from './NavButton'
  */
 export function QuickLinkMenu({
   ref,
+  // oxlint-disable-next-line no-unused-vars // TODO
   infoviewRef,
+  // oxlint-disable-next-line no-unused-vars // TODO
   editorRef,
 }: {
   ref?: RefObject<HTMLButtonElement | null>


### PR DESCRIPTION
- fix lint warnings by using the proper HTML-Tags or marking elements with `aria-hidden`
- add escape-hooks to escape the editor and close the navigation menu
- full tab-navigation through the page's header
- add stub quicklink-menu. This isn't imported yet as the links to the editor and infoview don't work yet. The infoview therefore remains unreachable via "tab".