### PR TITLE
fix: tab navigation

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -42,7 +42,7 @@ export function App() {
   const editorWrapperRef = useRef<HTMLDivElement>(null)
   const editorRef = useRef<HTMLDivElement>(null)
   const infoviewRef = useRef<HTMLDivElement>(null)
-  const firstItemRef = useRef<HTMLButtonElement>(null)
+  const firstItemRef = useRef<HTMLSelectElement>(null)
 
   const [dragging, setDragging] = useState<boolean | null>(false)
   const [editor, setEditor] = useState<monaco.editor.IStandaloneCodeEditor>()
@@ -517,6 +517,7 @@ export function App() {
           />
         )}
         <Menu
+          firstItemRef={firstItemRef}
           setContent={setContent}
           restart={() => {
             leanMonaco?.restart()

--- a/client/src/navigation/Navigation.tsx
+++ b/client/src/navigation/Navigation.tsx
@@ -20,7 +20,14 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useAtom } from 'jotai'
-import { ChangeEvent, Dispatch, SetStateAction, useState } from 'react'
+import {
+  ChangeEvent,
+  Dispatch,
+  RefObject,
+  SetStateAction,
+  useRef,
+  useState,
+} from 'react'
 
 import { lean4webConfig } from '../../config'
 import ZulipIcon from '../assets/zulip.svg'
@@ -86,6 +93,8 @@ function FlexibleMenu({
     setOpenLoad(false)
   }
 
+  const ref = useRef<HTMLInputElement>(null)
+
   return (
     <>
       <Dropdown
@@ -118,6 +127,12 @@ function FlexibleMenu({
           )),
         )}
       </Dropdown>
+      <input
+        ref={ref}
+        id="file-upload"
+        type="file"
+        onChange={loadFileFromDisk}
+      />
       <Dropdown
         open={openLoad}
         setOpen={setOpenLoad}
@@ -129,22 +144,14 @@ function FlexibleMenu({
           if (!isInDropdown) setOpenNav(false)
         }}
       >
-        <input
-          id="file-upload"
-          type="file"
-          onChange={loadFileFromDisk}
-          onClick={(ev) => ev.stopPropagation()}
-        />
-        {/* Need `ev.stopPropagation` to prevent closing until the file is loaded.
-          Otherwise the file-upload is destroyed too early. */}
-        {/* oxlint-disable-next-line jsx-a11y/click-events-have-key-events jsx-a11y/no-noninteractive-element-interactions */}
-        <label
-          htmlFor="file-upload"
+        <button
+          type="button"
           className="nav-link"
-          onClick={(ev) => ev.stopPropagation()}
+          onClick={() => ref.current?.click()}
         >
-          <FontAwesomeIcon icon={faUpload} /> Load file from disk
-        </label>
+          <FontAwesomeIcon icon={faUpload} aria-hidden="true" />
+          Load file from disk
+        </button>
         <NavButton
           icon={faCloudArrowUp}
           text="Load from URL"
@@ -183,12 +190,14 @@ export function Menu({
   codeMirror,
   setCodeMirror,
   handleJoinCollab,
+  firstItemRef,
 }: {
   setContent: (code: string) => void
   restart?: () => void
   codeMirror: boolean
   setCodeMirror: Dispatch<SetStateAction<boolean>>
   handleJoinCollab: () => void
+  firstItemRef?: RefObject<HTMLSelectElement | null>
 }) {
   const [visibleProjects] = useAtom(visibleProjectsAtom)
   const [project, setProject] = useAtom(currentProjectAtom)
@@ -216,6 +225,7 @@ export function Menu({
     <>
       {project && (
         <select
+          ref={firstItemRef}
           name="leanVersion"
           value={project.folder}
           onChange={(ev) => {


### PR DESCRIPTION
- fix: `esc` from editor now actually focuses the first menu item
- fix: "Load file from disk" is now accessible too